### PR TITLE
TASK: Relax Fusion composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "type": "neos-yeebase",
     "require": {
-        "neos/fusion": "~3.3.0 || ~4.0.0"
+        "neos/fusion": "~3.3.0 || ~4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This allows to install the package on Neos 4.x instead of 4.0.x

Resolves: #2 